### PR TITLE
chore: upgrade to latest snack-runtime package

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -70,7 +70,7 @@
     "react-native-webview": "11.23.0",
     "react-use": "^17.3.2",
     "snack-babel-standalone": "^2.2.0",
-    "snack-runtime": "0.2.0-alpha.2"
+    "snack-runtime": "0.2.0-alpha.4"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",


### PR DESCRIPTION
## Summary

I'm Cedric and I work with Expo, we are migrating our infrastructure for Snack to move off from pubnub into another service. To be able to edit a Snack on the website, that previews in PlayTorch, you'll need to upgrade to the latest version.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. -->

[CATEGORY] [TYPE] - Upgrade Snack Runtime to `0.2.0-alpha.4` for new socket infrastructure.

> Sorry, no idea what `category` or `type` could be 🙈 

## Test Plan

TBD, this would require testing the live preview of a Snack that's being edited on snack.expo.dev.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
